### PR TITLE
Fix up

### DIFF
--- a/dnsserver.go
+++ b/dnsserver.go
@@ -84,7 +84,7 @@ func dbLookup(queryResourceRecord DNSResourceRecord) ([]DNSResourceRecord, []DNS
 
 	for _, name := range names {
 		if strings.Contains(queryResourceRecord.DomainName, name.Name) {
-			fmt.Println(queryResourceRecord.DomainName)
+			fmt.Println(queryResourceRecord.DomainName, "resolved to", name.Address)
 			answerResourceRecords = append(answerResourceRecords, DNSResourceRecord{
 				DomainName:         name.Name,
 				Type:               TypeA,

--- a/dnsserver.go
+++ b/dnsserver.go
@@ -90,7 +90,7 @@ func dbLookup(queryResourceRecord DNSResourceRecord) ([]DNSResourceRecord, []DNS
 				Type:               TypeA,
 				Class:              ClassINET,
 				TimeToLive:         31337,
-				ResourceData:       name.Address, // ipv4 address
+				ResourceData:       name.Address[12:16], // ipv4 address
 				ResourceDataLength: 4,
 			})
 		}

--- a/lookupdb.go
+++ b/lookupdb.go
@@ -39,7 +39,7 @@ func GetNames() ([]Name, error) {
 }
 
 func To(models []NameModel) []Name {
-	names := make([]Name, len(models))
+	names := make([]Name, 0, len(models))
 	for _, value := range models {
 		names = append(names, Name{
 			Name:    value.Name,


### PR DESCRIPTION
Hey, @dlorch. Thanks for sharing this sweet bare-bones DNS server! I have a couple of improvements for you if you're interested:

1. Included the resolved IP address on stdout.
2. Updated `GetNames()` to avoid extra empty `Name` entries.
3. Updated `dbLookup()` to limit IP bytes to 4-byte IPv4 addresses.

Thanks again for the sweet sweet repo!

# With this PR

Note that:
1. `dig` reports an answer section with the correct IP address.

## dnsserver

```
$ go run .
Listening at:  :1053
Received request from  [::1]:58061
example.com resolved to 3.1.3.7
```

## dig

```
$ dig example.com @localhost -p 1053
; <<>> DiG 9.16.15-Debian <<>> example.com @localhost -p 1053
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 51881
;; flags: qr; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0

;; QUESTION SECTION:
;example.com.                   IN      A

;; ANSWER SECTION:
example.com.            31337   IN      A       3.1.3.7

;; Query time: 0 msec
;; SERVER: ::1#1053(::1)
;; WHEN: Sat Nov 13 03:46:42 PST 2021
;; MSG SIZE  rcvd: 56
```

# Before PR

Note that:
1. `dig` complains "Warning: Message parser reports malformed message packet."
2. `dig` reports no answer record.
3. `dnsserver` matches three records (two `Name{"", nil}` records, and the correct `Name{"example.com", "3.1.3.7"}` record)

## dnsserver

```
$ go run .
Listening at:  :1053
Received request from  [::1]:59333
example.com
example.com
example.com
```

## dig

```
$ dig example.com @localhost -p 1053
;; Warning: Message parser reports malformed message packet.

; <<>> DiG 9.16.15-Debian <<>> example.com @localhost -p 1053
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 36
;; flags: qr; QUERY: 1, ANSWER: 3, AUTHORITY: 0, ADDITIONAL: 0
;; WARNING: Message has 52 extra bytes at end

;; QUESTION SECTION:
;example.com.                   IN      A

;; Query time: 0 msec
;; SERVER: ::1#1053(::1)
;; WHEN: Sat Nov 13 03:48:15 PST 2021
;; MSG SIZE  rcvd: 92
```

# PR caveats

This the go version I used:
```
$ go version
go version go1.15.9 linux/amd64
```